### PR TITLE
chore: fixing wallet interaction

### DIFF
--- a/src/phan-wallet-mock.ts
+++ b/src/phan-wallet-mock.ts
@@ -1,4 +1,5 @@
 import {
+  clusterApiUrl,
   Commitment,
   Connection,
   ConnectionConfig,
@@ -20,11 +21,15 @@ import {
   TransactionWithInternals,
   verifySignatures,
 } from './web3js'
-import { LOCALNET } from 'test/utils'
 
 const logInfo = debug('phan:info')
 const logDebug = debug('phan:debug')
 const logError = debug('phan:error')
+
+export const DEVNET = clusterApiUrl('devnet')
+export const TESTNET = clusterApiUrl('testnet')
+export const MAINNET_BETA = clusterApiUrl('mainnet-beta')
+export const LOCALNET = 'http://127.0.0.1:8899'
 
 /**
  * Standin for the the [https://phantom.app/ | phantom wallet] to use while testing.
@@ -170,4 +175,13 @@ export class PhantomWalletMock
     keypair: Keypair,
     commitmentOrConfig?: Commitment | ConnectionConfig
   ) => new PhantomWalletMock(connectionURL, keypair, commitmentOrConfig)
+}
+
+export const initWalletMockProvider = (
+  win: Window & { solana: PhantomWallet | undefined }
+) => {
+  const payer = Keypair.generate()
+  const wallet = PhantomWalletMock.create(LOCALNET, payer, 'confirmed')
+  win.solana = wallet
+  return { wallet, payer }
 }

--- a/src/phan-wallet-mock.ts
+++ b/src/phan-wallet-mock.ts
@@ -8,7 +8,9 @@ import {
 } from '@solana/web3.js'
 import { EventEmitter } from 'eventemitter3'
 import { PhantomWallet, PhantomWalletEvents } from './types'
-import { strict as assert } from 'assert'
+import * as assert_module from 'assert'
+
+const assert: typeof import('assert') = assert_module.strict ?? assert_module
 
 import nacl from 'tweetnacl'
 import debug from 'debug'

--- a/src/phan-wallet-mock.ts
+++ b/src/phan-wallet-mock.ts
@@ -177,9 +177,8 @@ export class PhantomWalletMock
   ) => new PhantomWalletMock(connectionURL, keypair, commitmentOrConfig)
 }
 
-export const initWalletMockProvider = (
-  win: Window & { solana: PhantomWallet | undefined }
-) => {
+export const initWalletMockProvider = (winin: Window) => {
+  const win = winin as Window & { solana: PhantomWallet | undefined }
   const payer = Keypair.generate()
   const wallet = PhantomWalletMock.create(LOCALNET, payer, 'confirmed')
   win.solana = wallet

--- a/src/phan-wallet-mock.ts
+++ b/src/phan-wallet-mock.ts
@@ -8,7 +8,7 @@ import {
 } from '@solana/web3.js'
 import { EventEmitter } from 'eventemitter3'
 import { PhantomWallet, PhantomWalletEvents } from './types'
-import * as assert_module from 'assert'
+import assert_module from 'assert'
 
 const assert: typeof import('assert') = assert_module.strict ?? assert_module
 
@@ -18,6 +18,12 @@ import debug from 'debug'
 const logInfo = debug('phan:info')
 const logDebug = debug('phan:debug')
 const logError = debug('phan:error')
+
+function forceUint8Array(arrlike: Uint8Array): Uint8Array {
+  // Some Uint8Array we get here aren't accepted by nacl as `instanceof Uint8Array === false`
+  // Therefore we wrap it (again) to be very sure :)
+  return Uint8Array.from(arrlike)
+}
 
 /**
  * Standin for the the [https://phantom.app/ | phantom wallet] to use while testing.
@@ -103,7 +109,11 @@ export class PhantomWalletMock
     return new Promise(async (resolve, reject) => {
       try {
         assert(this._connection != null, 'Need to connect wallet first')
-        const signature = nacl.sign.detached(message, this._keypair.secretKey)
+        debugger
+        const signature = nacl.sign.detached(
+          forceUint8Array(message),
+          this._keypair.secretKey
+        )
         const res = {
           signature,
           publicKey: this._keypair.publicKey,

--- a/src/phan-wallet-mock.ts
+++ b/src/phan-wallet-mock.ts
@@ -123,7 +123,6 @@ export class PhantomWalletMock
     return new Promise(async (resolve, reject) => {
       try {
         assert(this._connection != null, 'Need to connect wallet first')
-        debugger
         const signature = nacl.sign.detached(
           forceUint8Array(message),
           this._keypair.secretKey

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,7 @@
+// Some Uint8Array we get here aren't accepted by nacl as `instanceof Uint8Array === false`
+// Therefore we wrap it (again) to be very sure :)
+export function forceUint8Array(arraylike: Uint8Array): Uint8Array {
+  if (arraylike instanceof Uint8Array) return arraylike
+
+  return Uint8Array.from(arraylike)
+}

--- a/src/web3js.ts
+++ b/src/web3js.ts
@@ -1,0 +1,79 @@
+import { Message, PublicKey, Signer, Transaction } from '@solana/web3.js'
+import nacl from 'tweetnacl'
+
+import { Buffer } from 'buffer'
+import { forceUint8Array } from './utils'
+
+export const toBuffer = (arr: Buffer | Uint8Array | Array<number>): Buffer => {
+  if (Buffer.isBuffer(arr)) {
+    return arr
+  } else if (arr instanceof Uint8Array) {
+    return Buffer.from(arr.buffer, arr.byteOffset, arr.byteLength)
+  } else {
+    return Buffer.from(arr)
+  }
+}
+
+type PartialSign = (
+  this: Transaction,
+  message: Message,
+  ...signers: Array<Signer>
+) => void
+
+type AddSignature = (
+  this: Transaction,
+  pubkey: PublicKey,
+  signature: Buffer
+) => void
+
+type VerifySignatures = (
+  this: Transaction,
+  signData: Buffer,
+  requireAllSignatures: boolean
+) => boolean
+
+export type TransactionWithInternals = Transaction & {
+  _partialSign: PartialSign
+  _addSignature: AddSignature
+  _verifySignatures: VerifySignatures
+}
+
+export function partialSign(
+  this: TransactionWithInternals,
+  message: Message,
+  ...signers: Array<Signer>
+) {
+  const serializedMessage = message.serialize()
+  const signData = forceUint8Array(serializedMessage)
+  signers.forEach((signer) => {
+    const secretKey = forceUint8Array(signer.secretKey)
+    const signature = nacl.sign.detached(signData, secretKey)
+    this._addSignature(signer.publicKey, toBuffer(signature))
+  })
+}
+
+export function verifySignatures(
+  this: TransactionWithInternals,
+  signData: Buffer,
+  requireAllSignatures: boolean
+): boolean {
+  for (const { signature, publicKey } of this.signatures) {
+    if (signature === null) {
+      if (requireAllSignatures) {
+        return false
+      }
+    } else {
+      const publicKeyBuf = publicKey.toBuffer()
+      if (
+        !nacl.sign.detached.verify(
+          forceUint8Array(signData),
+          forceUint8Array(signature),
+          forceUint8Array(publicKeyBuf)
+        )
+      ) {
+        return false
+      }
+    }
+  }
+  return true
+}

--- a/test/connection.test.ts
+++ b/test/connection.test.ts
@@ -1,6 +1,5 @@
 import { Keypair, Transaction } from '@solana/web3.js'
-import { PhantomWalletMock } from '../src/phan-wallet-mock'
-import { LOCALNET } from './utils'
+import { LOCALNET, PhantomWalletMock } from '../src/phan-wallet-mock'
 import test from 'tape'
 
 function setup(net = LOCALNET) {

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -1,5 +1,4 @@
 import {
-  clusterApiUrl,
   Connection,
   Keypair,
   LAMPORTS_PER_SOL,
@@ -8,13 +7,8 @@ import {
   SystemProgram,
   Transaction,
 } from '@solana/web3.js'
-import { PhantomWalletMock } from '../src/phan-wallet-mock'
+import { LOCALNET, PhantomWalletMock } from '../src/phan-wallet-mock'
 import * as util from 'util'
-
-export const DEVNET = clusterApiUrl('devnet')
-export const TESTNET = clusterApiUrl('testnet')
-export const MAINNET_BETA = clusterApiUrl('mainnet-beta')
-export const LOCALNET = 'http://127.0.0.1:8899'
 
 export const isCI = process.env.CI != null
 

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -1,7 +1,6 @@
 import {
   Connection,
   Keypair,
-  LAMPORTS_PER_SOL,
   PublicKey,
   sendAndConfirmTransaction,
   SystemProgram,
@@ -31,11 +30,7 @@ export async function setupWithPayer(
   const wallet = PhantomWalletMock.create(net, payer, 'confirmed')
 
   await wallet.connect()
-  const signature = await wallet.connection.requestAirdrop(
-    payer.publicKey,
-    LAMPORTS_PER_SOL * 5
-  )
-  await wallet.connection.confirmTransaction(signature)
+  await wallet.requestAirdrop(5)
 
   return { payer, wallet }
 }


### PR DESCRIPTION
- compat: not relying on assert.strict to be present
- sign: enforcing proper Uint8Array for messages to sign
- hack: enforcing Uint8Array instances where needed
- api: exposing init wallet mock provider function
- fix: localnet import
- api: taking generic window as input for mock provider init
- chore: remove debugger for signMessage
- api: exposing more properties and convenience methods
- feat: storing transaction signatures
